### PR TITLE
Fix h5netcdf dependency issue

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,3 +13,4 @@ dependencies:
   - boto3
   - cartopy
   - dask[array]
+  - h5netcdf

--- a/infrastructure/ecs.tf
+++ b/infrastructure/ecs.tf
@@ -31,28 +31,39 @@ resource "aws_iam_policy" "metoffice_task_policy" {
     "Version": "2012-10-17",
     "Statement": [
         {
-            "Sid": "",
+            "Sid": "sqs",
             "Effect": "Allow",
             "Action": [
                 "sqs:DeleteMessage",
                 "sqs:GetQueueUrl",
                 "sqs:ReceiveMessage",
                 "sqs:GetQueueAttributes",
-                "s3:ListBucket",
                 "sqs:ListQueueTags",
-                "s3:ReplicateObject",
-                "s3:PutObject",
-                "s3:GetObject",
-                "s3:GetObjectTorrent",
                 "sqs:ListDeadLetterSourceQueues",
-                "s3:AbortMultipartUpload",
-                "sqs:DeleteMessageBatch",
-                "s3:GetObjectVersionAcl",
-                "s3:GetObjectVersion"
+                "sqs:DeleteMessageBatch"
             ],
             "Resource": [
-                "${aws_sqs_queue.metqueue.arn}",
-                "${aws_s3_bucket.output.arn}",
+              "${aws_sqs_queue.metqueue.arn}"
+            ]
+        },
+        {
+            "Sid": "s3_bucket",
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "${aws_s3_bucket.output.arn}"
+            ]
+        },
+        {
+            "Sid": "s3_files",
+            "Effect": "Allow",
+            "Action": [
+                "s3:PutObject",
+                "s3:GetObject"
+            ],
+            "Resource": [
                 "${aws_s3_bucket.output.arn}/*"
             ]
         }

--- a/infrastructure/inputs.tf
+++ b/infrastructure/inputs.tf
@@ -20,7 +20,7 @@ variable "sqs_message_retention_seconds" {
 
 variable "docker_image_version" {
   type    = string
-  default = "1.1.1"
+  default = "1.1.2"
 }
 
 variable "sns_filter_policy" {


### PR DESCRIPTION
Via #23 we removed h5netcdf as a dependency.

It seems that some parts of the application rely on it though, see #23.

We are now reverting that to fix our deployment.