### PR TITLE
🐛 Fix handling 1D height_meters incorrectly

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Format the code with `black metoffice_ec2 scripts`.
 
 Check coding style with `flake8`.
 
-Fix import order with `isort -rc .`.
+Fix import order with `isort .`.
 
 Run static type checking with `mypy metoffice_ec2 scripts`.
 

--- a/metoffice_ec2/subset.py
+++ b/metoffice_ec2/subset.py
@@ -12,14 +12,18 @@ import xarray as xr
 
 def subset(
     dataset: xr.Dataset,
-    height_meters: Optional[List[int]] = None,
+    height_meters: Optional[Union[float, List[float]]] = None,
     north: Optional[float] = None,
     east: Optional[float] = None,
     south: Optional[float] = None,
     west: Optional[float] = None,
 ) -> xr.Dataset:
 
-    if height_meters is not None:
+    if (
+        height_meters is not None
+        and not isinstance(height_meters, float)
+        and len(height_meters) > 1
+    ):
         dataset = dataset.sel(height=height_meters)
 
     return dataset.loc[


### PR DESCRIPTION
This PR fixes how we handle `height_meters` on incoming messages.

There are various different values for this field on the incoming messages:
1. not set (attribute has no height)
2. list with a single height item
3. single float item as height
4. list with multiple heights

While we did handle most of these correctly, the code previously broke for the 2nd case above.
The list is set to contain one height value only. This is only set on the SNS Message though.
The NetCDF doesn't have the respective field populated.

That is why we are adding a check whether `height_meters` is a list of length greater 1 before we run select.
We also noticed that sometimes the height is a single float value instead of an array of length one.

Fixes #44